### PR TITLE
Remove non-mutating combine field, can be computed.

### DIFF
--- a/Sources/Monoid/Algebras/Monoid.swift
+++ b/Sources/Monoid/Algebras/Monoid.swift
@@ -1,24 +1,28 @@
 // TODO: should the generic be M?
 public struct Monoid<A> {
   public let empty: A
-  public let combine: (A, A) -> A
   public let mcombine: (inout A, A) -> Void
+
+  public var combine: (A, A) -> A {
+    return { lhs, rhs in
+      var result = lhs
+      self.mcombine(&result, rhs)
+      return result
+    }
+  }
 
   public init(empty: A, combine: @escaping (A, A) -> A) {
     self.empty = empty
-    self.combine = combine
     self.mcombine = { lhs, rhs in lhs = combine(lhs, rhs) }
   }
 
   public init(empty: A, mcombine: @escaping (inout A, A) -> Void) {
     self.empty = empty
     self.mcombine = mcombine
-    self.combine = { lhs, rhs in var lhs = lhs; mcombine(&lhs, rhs); return lhs }
   }
 
   public init(empty: A, semigroup: Semigroup<A>) {
     self.empty = empty
-    self.combine = semigroup.combine
     self.mcombine = semigroup.mcombine
   }
 

--- a/Sources/Monoid/Algebras/Semigroup.swift
+++ b/Sources/Monoid/Algebras/Semigroup.swift
@@ -1,11 +1,17 @@
 // TODO: should the generic be S?
 public struct Semigroup<A> {
   // Law: `combine(combine(a, b), c) == combine(a, combine(b, c))` for all a, b, c: A.
-  public let combine: (A, A) -> A
   public let mcombine: (inout A, A) -> Void
 
+  public var combine: (A, A) -> A {
+    return { lhs, rhs in
+      var result = lhs
+      self.mcombine(&result, rhs)
+      return result
+    }
+  }
+
   public init(combine: @escaping (A, A) -> A) {
-    self.combine = combine
     self.mcombine = { accum, a in
       let result = combine(accum, a)
       accum = result
@@ -14,11 +20,6 @@ public struct Semigroup<A> {
 
   public init(mcombine: @escaping (inout A, A) -> Void) {
     self.mcombine = mcombine
-    self.combine = { accum, a in
-      var copy = accum
-      mcombine(&copy, a)
-      return copy
-    }
   }
 
   func imap<B>(_ f: @escaping (A) -> B, _ g: @escaping (B) -> A) -> Semigroup<B> {


### PR DESCRIPTION
Opening this PR against the `monoid` branch.

No need to have `combine` and `mcombine` fields...