### PR TITLE
Rename array to concat.

### DIFF
--- a/Sources/Monoid/Instances/RangeReplaceableCollection.swift
+++ b/Sources/Monoid/Instances/RangeReplaceableCollection.swift
@@ -1,12 +1,12 @@
 extension Semigroup where A: RangeReplaceableCollection {
   // TODO: what to name this? `concat`? `append`?
-  public static var array: Semigroup<A> {
+  public static var concat: Semigroup<A> {
     return Semigroup<A>(mcombine: { $0.append(contentsOf: $1) })
   }
 }
 
 extension Monoid where A: RangeReplaceableCollection {
-  public static var array: Monoid<A> {
-    return Monoid<A>(empty: .init(), semigroup: .array)
+  public static var concat: Monoid<A> {
+    return Monoid<A>(empty: .init(), semigroup: .concat)
   }
 }

--- a/Sources/Monoid/Instances/RangeReplaceableCollection.swift
+++ b/Sources/Monoid/Instances/RangeReplaceableCollection.swift
@@ -1,12 +1,22 @@
 extension Semigroup where A: RangeReplaceableCollection {
-  // TODO: what to name this? `concat`? `append`?
-  public static var concat: Semigroup<A> {
+  public static var joined: Semigroup<A> {
     return Semigroup<A>(mcombine: { $0.append(contentsOf: $1) })
+  }
+
+  public static func joined(separator: A.Element) -> Semigroup<A> {
+    return Semigroup<A>(mcombine: {
+      if !$0.isEmpty { $0.append(separator) }
+      $0.append(contentsOf: $1)
+    })
   }
 }
 
 extension Monoid where A: RangeReplaceableCollection {
-  public static var concat: Monoid<A> {
-    return Monoid<A>(empty: .init(), semigroup: .concat)
+  public static var joined: Monoid<A> {
+    return Monoid<A>(empty: .init(), semigroup: .joined)
+  }
+
+  public static func joined(separator: A.Element) -> Monoid<A> {
+    return Monoid<A>(empty: .init(), semigroup: .joined(separator: separator))
   }
 }

--- a/Tests/MonoidTests/MonoidTests.swift
+++ b/Tests/MonoidTests/MonoidTests.swift
@@ -60,15 +60,15 @@ final class MonoidTests: XCTestCase {
   func testMerge() {
     XCTAssertEqual(
       [1: "oneuno", 2: "twodos"],
-      Semigroup.merge(with: .array).combine([1: "one", 2: "two"], [1: "uno", 2: "dos"])
+      Semigroup.merge(with: .concat).combine([1: "one", 2: "two"], [1: "uno", 2: "dos"])
     )
 
     XCTAssertEqual(
       [1: "oneuno", 2: "twodos"],
-      Monoid.merge(with: .array).fold([[1: "one", 2: "two"], [1: "uno", 2: "dos"]])
+      Monoid.merge(with: .concat).fold([[1: "one", 2: "two"], [1: "uno", 2: "dos"]])
     )
 
-    XCTAssertEqual([Int: String](), Monoid.merge(with: .array).fold([]))
+    XCTAssertEqual([Int: String](), Monoid.merge(with: .concat).fold([]))
   }
 
   func testEnd() {
@@ -120,11 +120,11 @@ final class MonoidTests: XCTestCase {
   }
 
   func testPointwise() {
-    let f: (Int) -> [String] = Semigroup.pointwise(into: .array)
+    let f: (Int) -> [String] = Semigroup.pointwise(into: .concat)
       .combine({ ["\($0)", "\($0)"] }, { ["\($0)", "\($0)", "\($0)"] })
-    let g: (Int) -> [String] = Monoid.pointwise(into: .array)
+    let g: (Int) -> [String] = Monoid.pointwise(into: .concat)
       .fold([{ ["\($0)", "\($0)"] }, { ["\($0)", "\($0)", "\($0)"] }])
-    let h: (Int) -> [String] = Monoid.pointwise(into: .array).fold([])
+    let h: (Int) -> [String] = Monoid.pointwise(into: .concat).fold([])
 
     XCTAssertEqual(["1", "1", "1", "1", "1"], f(1))
     XCTAssertEqual(["1", "1", "1", "1", "1"], g(1))
@@ -133,9 +133,9 @@ final class MonoidTests: XCTestCase {
 
   func testTuple() {
     // TODO: `Semigroup.` is needed here because of the convenience `combine` on Monoid. is it worth it?
-    XCTAssertEqual((3, "HelloWorld"), tuple2(Semigroup.sum, .array).combine((1, "Hello"), (2, "World")))
+    XCTAssertEqual((3, "HelloWorld"), tuple2(Semigroup.sum, .concat).combine((1, "Hello"), (2, "World")))
     
-    XCTAssertEqual((3, "HelloWorld"), tuple2(.sum, .array).fold([(1, "Hello"), (2, "World")]))
+    XCTAssertEqual((3, "HelloWorld"), tuple2(.sum, .concat).fold([(1, "Hello"), (2, "World")]))
   }
 
   func testAverage() {

--- a/Tests/MonoidTests/MonoidTests.swift
+++ b/Tests/MonoidTests/MonoidTests.swift
@@ -57,18 +57,25 @@ final class MonoidTests: XCTestCase {
     XCTAssertEqual(Float.greatestFiniteMagnitude, Monoid.min.fold([]))
   }
 
+  func testJoin() {
+    XCTAssertEqual(
+      "one-two-three",
+      ["one", "two", "three"].fold(.joined(separator: "-"))
+    )
+  }
+
   func testMerge() {
     XCTAssertEqual(
       [1: "oneuno", 2: "twodos"],
-      Semigroup.merge(with: .concat).combine([1: "one", 2: "two"], [1: "uno", 2: "dos"])
+      Semigroup.merge(with: .joined).combine([1: "one", 2: "two"], [1: "uno", 2: "dos"])
     )
 
     XCTAssertEqual(
       [1: "oneuno", 2: "twodos"],
-      Monoid.merge(with: .concat).fold([[1: "one", 2: "two"], [1: "uno", 2: "dos"]])
+      Monoid.merge(with: .joined).fold([[1: "one", 2: "two"], [1: "uno", 2: "dos"]])
     )
 
-    XCTAssertEqual([Int: String](), Monoid.merge(with: .concat).fold([]))
+    XCTAssertEqual([Int: String](), Monoid.merge(with: .joined).fold([]))
   }
 
   func testEnd() {
@@ -120,11 +127,11 @@ final class MonoidTests: XCTestCase {
   }
 
   func testPointwise() {
-    let f: (Int) -> [String] = Semigroup.pointwise(into: .concat)
+    let f: (Int) -> [String] = Semigroup.pointwise(into: .joined)
       .combine({ ["\($0)", "\($0)"] }, { ["\($0)", "\($0)", "\($0)"] })
-    let g: (Int) -> [String] = Monoid.pointwise(into: .concat)
+    let g: (Int) -> [String] = Monoid.pointwise(into: .joined)
       .fold([{ ["\($0)", "\($0)"] }, { ["\($0)", "\($0)", "\($0)"] }])
-    let h: (Int) -> [String] = Monoid.pointwise(into: .concat).fold([])
+    let h: (Int) -> [String] = Monoid.pointwise(into: .joined).fold([])
 
     XCTAssertEqual(["1", "1", "1", "1", "1"], f(1))
     XCTAssertEqual(["1", "1", "1", "1", "1"], g(1))
@@ -133,9 +140,9 @@ final class MonoidTests: XCTestCase {
 
   func testTuple() {
     // TODO: `Semigroup.` is needed here because of the convenience `combine` on Monoid. is it worth it?
-    XCTAssertEqual((3, "HelloWorld"), tuple2(Semigroup.sum, .concat).combine((1, "Hello"), (2, "World")))
+    XCTAssertEqual((3, "HelloWorld"), tuple2(Semigroup.sum, .joined).combine((1, "Hello"), (2, "World")))
     
-    XCTAssertEqual((3, "HelloWorld"), tuple2(.sum, .concat).fold([(1, "Hello"), (2, "World")]))
+    XCTAssertEqual((3, "HelloWorld"), tuple2(.sum, .joined).fold([(1, "Hello"), (2, "World")]))
   }
 
   func testAverage() {


### PR DESCRIPTION
What do you like better, `Monoid<RangeReplaceableCollection>.concat` or `Monoid<RangeReplaceableCollection>.append`?